### PR TITLE
chore: rename 'Ice Host' label to 'Ice' on admin page

### DIFF
--- a/app/host/page.tsx
+++ b/app/host/page.tsx
@@ -559,7 +559,7 @@ export default function HostPage() {
                 Launch a session
               </p>
               <h1 className="text-4xl font-display font-bold text-foreground sm:text-5xl">
-                Ice Host
+                Ice
               </h1>
             </div>
 


### PR DESCRIPTION
Simplified the heading on the host page from 'Ice Host' to just 'Ice' for a cleaner, more concise presentation.