### PR TITLE
Fix horizontal centering of Leave button in Phase 2

### DIFF
--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -1091,16 +1091,18 @@ function UserPageContent() {
         </AnimatePresence>
 
         {/* Leave button - fixed at bottom */}
-        <motion.button
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.3 }}
-          onClick={handleLeaveRoom}
-          className="fixed bottom-6 left-1/2 -translate-x-1/2 px-8 py-3 text-lg font-semibold text-foreground bg-background border-2 border-border rounded-xl hover:bg-muted transition-colors shadow-lg"
-          aria-label="Leave room"
-        >
-          Leave
-        </motion.button>
+        <div className="fixed bottom-6 left-0 right-0 flex justify-center pointer-events-none">
+          <motion.button
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.3 }}
+            onClick={handleLeaveRoom}
+            className="px-8 py-3 text-lg font-semibold text-foreground bg-background border-2 border-border rounded-xl hover:bg-muted transition-colors shadow-lg pointer-events-auto"
+            aria-label="Leave room"
+          >
+            Leave
+          </motion.button>
+        </div>
       </main>
     );
   }
@@ -1125,16 +1127,18 @@ function UserPageContent() {
         </motion.div>
 
         {/* Leave button - fixed at bottom */}
-        <motion.button
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.3 }}
-          onClick={handleLeaveRoom}
-          className="fixed bottom-6 left-1/2 -translate-x-1/2 px-8 py-3 text-lg font-semibold text-foreground bg-background border-2 border-border rounded-xl hover:bg-muted transition-colors shadow-lg"
-          aria-label="Leave room"
-        >
-          Leave
-        </motion.button>
+        <div className="fixed bottom-6 left-0 right-0 flex justify-center pointer-events-none">
+          <motion.button
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.3 }}
+            onClick={handleLeaveRoom}
+            className="px-8 py-3 text-lg font-semibold text-foreground bg-background border-2 border-border rounded-xl hover:bg-muted transition-colors shadow-lg pointer-events-auto"
+            aria-label="Leave room"
+          >
+            Leave
+          </motion.button>
+        </div>
       </main>
     );
   }


### PR DESCRIPTION
## Summary

Fixes the Leave button horizontal centering issue in Phase 2 states (voting, waiting, reveal, and complete).

## Problem

The Leave button was not properly centered horizontally due to transform conflicts between Tailwind's `translate-x-1/2` utility and Framer Motion's animation transforms on the same element.

## Solution

Changed the centering approach to:
- Wrap the button in a fixed-position container that spans full width (`left-0 right-0`)
- Use flexbox (`flex justify-center`) for reliable centering
- Apply `pointer-events-none` to the container and `pointer-events-auto` to the button to maintain clickability

## Changes

- `app/user/page.tsx`: Updated Leave button markup in both Phase 2 states (slideshow viewing and complete)

## Test plan

- [x] Load user page during Phase 2 slideshow
- [x] Verify Leave button is horizontally centered at bottom of screen
- [x] Verify Leave button is clickable and functions correctly
- [x] Verify button animation still works as expected
- [x] Test on both "phase2_voting/waiting/reveal" and "phase2_complete" states

🤖 Generated with [Claude Code](https://claude.com/claude-code)