### PR TITLE
Implement room-based question rotation to minimize duplicates

### DIFF
--- a/convex/rooms.ts
+++ b/convex/rooms.ts
@@ -149,6 +149,7 @@ export const createRoom = mutation({
       phase1Active: false,
       phase1Duration: args.phase1Duration,
       maxGroupSize: args.maxGroupSize || 4,
+      nextQuestionIndex: 0,
       createdAt: now,
       expiresAt: now + fortyEightHours,
     });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -11,6 +11,7 @@ export default defineSchema({
     phase1StartedAt: v.optional(v.number()),
     windingDownStartedAt: v.optional(v.number()), // When winding down period begins
     maxGroupSize: v.number(), // Maximum users per group (default 4)
+    nextQuestionIndex: v.optional(v.number()), // Tracks next question position in room's sequence (0-based, defaults to 0)
     createdAt: v.number(),
     expiresAt: v.number(), // Room expires after 7 days
   })

--- a/convex/testData.ts
+++ b/convex/testData.ts
@@ -17,6 +17,7 @@ export const generateTestRoom = mutation({
       phase1Duration: 600, // 10 minutes
       phase1StartedAt: now - 600000, // Started 10 minutes ago (finished)
       maxGroupSize: 4,
+      nextQuestionIndex: 0,
       createdAt: now,
       expiresAt: now + fortyEightHours,
     });


### PR DESCRIPTION
## Summary
- Replaces date-based deterministic shuffle with room-specific sequential rotation
- Each room gets unique question sequence (seeded by roomId) 
- Groups progress through Q1 → Q2 → Q3... in their room's order
- Hybrid filtering respects user history (last 3 questions) when possible
- With ~411 questions in database, provides excellent variety

## Changes

**Algorithm improvements:**
- Room-specific shuffle ensures different rooms have different question orders
- Sequential progression with smart lookahead (searches 50 positions ahead)
- Fallback to next question if all recent options were already seen
- Automatic counter increment after each group selection

**Database schema:**
- Added `nextQuestionIndex` field to rooms table (optional for backward compatibility)
- Initialized to 0 for all new rooms
- Updated `selectQuestion` function signature to accept roomId parameter

**Files modified:**
- `convex/schema.ts` - Add nextQuestionIndex to rooms table
- `convex/rooms.ts` - Initialize nextQuestionIndex on room creation  
- `convex/groups.ts` - Rewrite selectQuestion with room-based algorithm
- `convex/testData.ts` - Add nextQuestionIndex to test data generation

## Test plan
- [ ] Create new room and verify nextQuestionIndex starts at 0
- [ ] Form multiple groups in same room and verify sequential progression
- [ ] Verify different rooms get different question sequences
- [ ] Test user history filtering (users don't see recently answered questions)
- [ ] Verify backward compatibility with existing rooms (optional field)
- [ ] Test fallback behavior when user has seen many recent questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)