### PR TITLE
Fix dark mode styling on question choice page

### DIFF
--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -809,7 +809,7 @@ function UserPageContent() {
     const canComplete = elapsedTime >= 60;
 
     return (
-      <main className="flex min-h-screen flex-col items-center justify-center p-3 sm:p-8 bg-gradient-to-b from-yellow-50 to-white">
+      <main className="flex min-h-screen flex-col items-center justify-center p-3 sm:p-8 bg-gradient-to-b from-yellow-50 to-white dark:from-gray-900 dark:to-gray-800">
         <TitleBar />
         {/* Show subtle banner for incoming requests during active session */}
         {incomingRequests && incomingRequests.length > 0 && (
@@ -840,7 +840,7 @@ function UserPageContent() {
           className="w-full max-w-2xl space-y-3 sm:space-y-8"
         >
           <div className="text-center">
-            <h2 className="text-xl sm:text-3xl font-bold text-gray-900 mb-3 sm:mb-8 leading-tight">
+            <h2 className="text-xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-3 sm:mb-8 leading-tight">
               {question?.text}
             </h2>
           </div>


### PR DESCRIPTION
## Summary
- Fixed dark mode background gradient on the "Would you rather" question choice page
- Fixed dark mode text color for the question heading

## Details
The question_active state in `/app/user/page.tsx` had hardcoded light styling that didn't respond to dark mode:
- Background was stuck on `from-yellow-50 to-white`
- Question heading text was stuck on `text-gray-900`

Now properly includes dark mode classes:
- Background: `dark:from-gray-900 dark:to-gray-800`
- Heading: `dark:text-gray-100`

## Test plan
- [ ] Enable dark mode in settings
- [ ] Join a room and form a group
- [ ] Verify the question choice page shows dark background gradient
- [ ] Verify the "Would you rather" text is light/readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)